### PR TITLE
Check if Settle is being run as root

### DIFF
--- a/settle/main.py
+++ b/settle/main.py
@@ -28,6 +28,9 @@ def main():
     # Get package manager class
     package_manager = get_package_manager()
 
+    # Check if Settle is being run by root (root has uid == 0)
+    add_sudo = (os.getuid() != 0)
+
     # Ask questions
     asker = Asker(packages, default_packages, package_manager)
     answers = asker.ask_questions()
@@ -39,7 +42,7 @@ def main():
     # Initialize package manager
     if "package_manager" in answers:
         package_manager = answers["package_manager"]
-    package_manager = getattr(package_managers, package_manager)()
+    package_manager = getattr(package_managers, package_manager)(sudo=add_sudo)
 
     # Run tasks
     if answers["update_packages"]:

--- a/settle/package_managers.py
+++ b/settle/package_managers.py
@@ -32,7 +32,8 @@ class BaseManager(object):
     This is not intended to be used directly, just to subclass it.
     """
 
-    def __init__(self):
+    def __init__(self, sudo):
+        self.sudo = sudo
         self._lists_updated = False
 
     @property
@@ -72,8 +73,7 @@ class Pacman(BaseManager):
     """
 
     def __init__(self, sudo=True):
-        super().__init__()
-        self.sudo = sudo
+        super().__init__(sudo=sudo)
         self.commands = {
             "update_lists": "pacman -Sy",
             "update_packages": "pacman -Su",
@@ -87,8 +87,7 @@ class Apt(BaseManager):
     """
 
     def __init__(self, sudo=True):
-        super().__init__()
-        self.sudo = sudo
+        super().__init__(sudo=sudo)
         self.commands = {
             "update_lists": "apt-get update",
             "update_packages": "apt-get upgrade",


### PR DESCRIPTION
If Settle is being run as root, then initialize the package manager with 
`sudo == False` so the commands are run directly without asking for root
permissions. Pass the sudo argument of package manager child classes to the
parent constructor through super, so we don't need to define the sudo attribute
on each child class.


Fixes #18 