### PR TITLE
Add option to list all packages instead of categories

### DIFF
--- a/settle/argparser.py
+++ b/settle/argparser.py
@@ -20,4 +20,10 @@ def create_argparser():
         help=PACKAGES_HELP_LINE,
         default="",
     )
+    parser.add_argument(
+        "--list-packages",
+        "-l",
+        action="store_true",
+        help="list all packages inside packages.yml instead of showing categories",
+    )
     return parser

--- a/settle/io.py
+++ b/settle/io.py
@@ -9,16 +9,16 @@ def read_packages_yaml(packages_yaml):
     Read packages YAML file
     """
     packages = yaml.load(packages_yaml, Loader=yaml.FullLoader)
-    # Pop default packages if any
-    default_packages = []
+    # Pop default categories if any
+    default_categories = []
     if "default" in packages:
-        default_packages = packages.pop("default")
-        _check_valid_default_packages(packages, default_packages)
-    return packages, default_packages
+        default_categories = packages.pop("default")
+        _check_valir_default_categories(packages, default_categories)
+    return packages, default_categories
 
 
-def _check_valid_default_packages(packages, default):
-    "Check if the groups in default are valid"
+def _check_valir_default_categories(packages, default):
+    "Check if the categories in default are valid"
     missing_groups = [group for group in default if group not in packages]
     if missing_groups:
         if len(missing_groups) == 1:

--- a/settle/main.py
+++ b/settle/main.py
@@ -23,7 +23,7 @@ def main():
     arguments = parser.parse_args()
 
     # Read packages.yml and get defaults
-    packages, default_packages = read_packages_yaml(arguments.packages)
+    packages_dict, default_categories = read_packages_yaml(arguments.packages)
 
     # Get package manager class
     package_manager = get_package_manager()
@@ -32,7 +32,12 @@ def main():
     add_sudo = os.getuid() != 0
 
     # Ask questions
-    asker = Asker(packages, default_packages, package_manager)
+    asker = Asker(
+        packages_dict,
+        default_categories,
+        package_manager,
+        list_packages=arguments.list_packages,
+    )
     answers = asker.ask_questions()
 
     # Continue only if the last confirmation question is true


### PR DESCRIPTION
Add Asker the ability to show question for categories or packages if
list-packages is False or True, respectively. Add Asker a method for
creating the list of packages that must be installed. Rename
default_packages to default_categories: it's a better name for a list
that contains default categories and not package names.

Fixes #2